### PR TITLE
fix: adding additional domains to the allowlist

### DIFF
--- a/allowlist.txt
+++ b/allowlist.txt
@@ -398,4 +398,5 @@ yahoo.se
 yandex.ru
 yeah.net
 yepmail.net
+ymail.com
 your-mail.com

--- a/allowlist.txt
+++ b/allowlist.txt
@@ -400,3 +400,4 @@ yeah.net
 yepmail.net
 ymail.com
 your-mail.com
+zoho.com

--- a/allowlist.txt
+++ b/allowlist.txt
@@ -236,6 +236,7 @@ mailservice.ms
 mailsire.com
 mailup.net
 mailworks.org
+me.com
 memeware.net
 mindless.com
 ml1.net


### PR DESCRIPTION
me.com is owned by apple
ymail.com is owned by yahoo
zoho.com is also a legit domain